### PR TITLE
Enable use from OOD by supporting GnuPG >= 2.1

### DIFF
--- a/mosrs/accessdev.py
+++ b/mosrs/accessdev.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""
+Copyright 2016 ARC Centre of Excellence for Climate Systems Science
+
+author: Scott Wales <scott.wales@unimelb.edu.au>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from . import gpg
+from getpass import getpass
+from hashlib import md5
+import requests
+import os
+import urllib3
+
+def main():
+    passwd = getpass('Please enter your password for user %s: '%os.environ['USER'])
+
+    # See https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings 
+    urllib3.disable_warnings()
+    # Test the password
+    r = requests.get('https://accessdev.nci.org.au/trac/login',
+            auth=(os.environ['USER'], passwd), verify=False)
+    if r.status_code == 401:
+        print('ERROR: Bad password for user %s'%os.environ['USER'])
+        return
+    r.raise_for_status()
+
+    realm = '<https://accessdev.nci.org.au:443> Accessdev'
+    key = md5(realm).hexdigest()
+    gpg.preset_passphrase(key, passwd)
+
+    realm = '<https://trac.nci.org.au:443> NCI Projects'
+    key = md5(realm).hexdigest()
+    gpg.preset_passphrase(key, passwd)
+
+    print('SUCCESS: Password saved in gpg-agent for user %s'%os.environ['USER'])
+
+if __name__ == '__main__':
+    main()

--- a/mosrs/gpg.py
+++ b/mosrs/gpg.py
@@ -36,7 +36,7 @@ def get_passphrase(cache_id):
 
     https://www.gnupg.org/documentation/manuals/gnupg/Agent-GET_005fPASSPHRASE.html
     """
-    stdout = send("GET_PASSPHRASE --data %s X X X\n"%cache_id)
+    stdout = send("GET_PASSPHRASE --no-ask --data %s X X X\n"%cache_id)
     return unquote(stdout[0][2:])
 
 def clear_passphrase(cache_id):

--- a/mosrs/setup.py
+++ b/mosrs/setup.py
@@ -91,8 +91,9 @@ def prompt_or_default(prompt, default):
 def gpg_startup():
     agent = dedent("""
     if gpg-agent --use-standard-socket-p; then
-        # New GPG always returns 0. Restart the agent
-        gpg-connect-agent reloadagent /bye
+        # New GPG always returns 0.
+        # Ensure that the agent is running.
+        gpg-connect-agent /bye
         export GPG_TTY=$(tty)
         export GPG_AGENT_INFO=$HOME/.gnupg/S.gpg-agent:0:1
     else

--- a/mosrs/setup.py
+++ b/mosrs/setup.py
@@ -24,6 +24,7 @@ from os import environ, path
 from distutils.util import strtobool
 import ldap
 import getpass
+import socket
 
 from . import auth, gpg
 
@@ -89,13 +90,21 @@ def prompt_or_default(prompt, default):
 
 def gpg_startup():
     agent = dedent("""
+    if gpg-agent --use-standard-socket-p; then
+        # New GPG always returns 0. Restart the agent
+        gpg-connect-agent reloadagent /bye
+        export GPG_TTY=$(tty)
+        export GPG_AGENT_INFO=$HOME/.gnupg/S.gpg-agent:0:1
+    else
+        # Old GPG
         [ -f ~/.gpg-agent-info ] && source ~/.gpg-agent-info
         if [ -S "${GPG_AGENT_INFO%%:*}" ]; then
             export GPG_AGENT_INFO
         else
             eval $( gpg-agent --daemon --allow-preset-passphrase --batch --max-cache-ttl 43200 --write-env-file ~/.gpg-agent-info )
         fi
-        """)
+    fi
+    """)
     home = environ['HOME']
     for f in ['.profile','.bash_profile']:
         p = path.join(home,f)
@@ -112,8 +121,10 @@ def gpg_startup():
             with open(p,'a') as profile:
                 profile.write(agent)
 
+    host = "OOD" if on_ood() else "Accessdev"
     todo('GPG Agent has been added to your startup scripts. '+
-            'Please log out of Accessdev then back in again to make sure it has been activated\n')
+            'Please log out of ' + host +
+            ' then back in again to make sure it has been activated\n')
 
 
 def check_gpg_agent():
@@ -162,7 +173,7 @@ def setup_mosrs_account():
     else:
         print(dedent(
             """
-            If you need to access new versions of the UM please send a 
+            If you need to access new versions of the UM please send a
             request to 'cws_help@nci.org.au' saying that you'd like a MOSRS account
 
             Once you have an account run this script again
@@ -204,15 +215,23 @@ def accesssvn_setup():
     except SetupError:
         todo('Once this has been done please run this setup script again\n')
 
+def on_ood():
+    hostname = socket.gethostname()
+    return hostname.startswith("ood")
+
 def main():
     print('\n')
-    print('Welcome to Accessdev, the user interface and control server for the ACCESS model at NCI')
+    if on_ood():
+        print('Welcome to OOD, the NCI Open OnDemand service')
+    else:
+        print('Welcome to Accessdev, the user interface and control server for the ACCESS model at NCI')
     print('This script will set up your account to use Rose and the UM\n')
 
     try:
         setup_mosrs_account()
 
-        check_gadi_ssh()
+        if not on_ood():
+            check_gadi_ssh()
 
         # Account successfully created
         print('You are now able to use Rose and the UM. To see a list of available experiments run:')

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
                 'mosrs-auth  = mosrs.auth:main',
                 'mosrs-setup = mosrs.setup:main',
                 'access-auth = mosrs.access:main',
+                'accessdev-auth = mosrs.accessdev:main',
                 'accesssvn-setup = mosrs.setup:accesssvn_setup',
                 ]
             }


### PR DESCRIPTION
Closes #8 

This change should enable users of OOD to cache both MOSRS and NCI credentials for use with FCM, Subversion and Rose. More extensive testing is likely needed, both on OOD and on accessdev.
